### PR TITLE
Add tested support for g1 (2016-2018) vehicles

### DIFF
--- a/subarulink/__init__.py
+++ b/subarulink/__init__.py
@@ -13,6 +13,7 @@ from subarulink.exceptions import (
     InvalidPIN,
     PINLockoutProtect,
     SubaruException,
+    VehicleNotSupported,
 )
 
 from .__version__ import __version__
@@ -24,6 +25,7 @@ __all__ = [
     "InvalidPIN",
     "IncompleteCredentials",
     "PINLockoutProtect",
+    "VehicleNotSupported",
     "const",
     "__version__",
 ]

--- a/subarulink/__version__.py
+++ b/subarulink/__version__.py
@@ -5,4 +5,4 @@ subarulink - A Python Package for interacting with Subaru Starlink Remote Servic
 For more details about this api, please refer to the documentation at
 https://github.com/G-Two/subarulink
 """
-__version__ = "0.3.10rc0"
+__version__ = "0.3.10rc1"

--- a/subarulink/__version__.py
+++ b/subarulink/__version__.py
@@ -5,4 +5,4 @@ subarulink - A Python Package for interacting with Subaru Starlink Remote Servic
 For more details about this api, please refer to the documentation at
 https://github.com/G-Two/subarulink
 """
-__version__ = "0.3.9"
+__version__ = "0.3.10rc0"

--- a/subarulink/app/cli.py
+++ b/subarulink/app/cli.py
@@ -61,14 +61,14 @@ class CLI:  # pylint: disable=too-few-public-methods
         if os.path.isfile(self._config_file):
             LOGGER.info("Opening config file: %s", self._config_file)
             try:
-                infile = open(self._config_file, "r")
+                infile = open(self._config_file)
                 config_json = infile.read()
             except UnicodeDecodeError:
                 # Update previous version's shelve config file to json
                 LOGGER.warning(f"Updating {self._config_file} to JSON format.")
                 infile.close()
                 self._convert_to_json(self._config_file)
-                infile = open(self._config_file, "r")
+                infile = open(self._config_file)
                 config_json = infile.read()
             infile.close()
             saved_config = json.loads(config_json)
@@ -339,10 +339,10 @@ class CLI:  # pylint: disable=too-few-public-methods
                 LOGGER.info("Successfully connected")
                 self._cars = self._ctrl.get_vehicles()
                 await self._vehicle_select(interactive, vin)
-                if interactive and self._current_api_gen == "g2":
+                if interactive:
                     await self._fetch()
                     self._show(["summary"])
-                elif self._current_api_gen == "g1":
+                if self._current_api_gen == "g1":
                     LOGGER.warning(
                         "%s is a Generation 1 telematics vehicle which has not been tested." % self._current_name
                     )
@@ -380,10 +380,10 @@ class CLI:  # pylint: disable=too-few-public-methods
                     print("  unlock       - unlock vehicle doors")
                     print("  lights       - turn on lights")
                     print("  horn         - sound horn")
-                    if self._current_api_gen == "g2":
-                        print("  show         - show vehicle information")
+                    print("  fetch        - fetch most recent update")
+                    print("  show         - show vehicle information")
+                    if self._current_hasRemote:
                         print("  update       - request update from vehicle")
-                        print("  fetch        - fetch most recent update")
                     if self._current_hasEV:
                         print("  charge       - start EV charging")
                     if self._current_hasRES or self._current_hasEV:
@@ -409,14 +409,14 @@ class CLI:  # pylint: disable=too-few-public-methods
                 elif cmd == "horn":
                     await self._ctrl.horn(self._current_vin)
 
-                elif cmd == "show" and self._current_api_gen == "g2":
+                elif cmd == "show":
                     self._show(args)
 
-                elif cmd == "update" and self._current_api_gen == "g2":
+                elif cmd == "update" and self._current_hasRemote:
                     await self._ctrl.update(self._current_vin)
                     await self._fetch()
 
-                elif cmd == "fetch" and self._current_api_gen == "g2":
+                elif cmd == "fetch":
                     await self._fetch()
 
                 elif cmd == "charge" and self._current_hasEV:
@@ -426,7 +426,7 @@ class CLI:  # pylint: disable=too-few-public-methods
                     await self._remote_start(args)
 
                 else:
-                    print("invalid command: {}".format(cmd))
+                    print(f"invalid command: {cmd}")
 
             except SubaruException as exc:
                 LOGGER.error("SubaruException caught: %s", exc.message)
@@ -508,19 +508,21 @@ class CLI:  # pylint: disable=too-few-public-methods
 
 
 def _km_to_miles(meters):
-    return float(meters) * 0.62137119
+    return float(meters or 0) * 0.62137119
 
 
 def _c_to_f(temp_c):
-    return float(temp_c) * 1.8 + 32.0
+    return float(temp_c or 0) * 1.8 + 32.0
 
 
 def _L100km_to_mpg(L100km):
-    return round(235.215 / L100km, 1)
+    if L100km:
+        return round(235.215 / L100km, 1)
+    return 0
 
 
 def _kpa_to_psi(kpa):
-    return kpa / 68.95
+    return (kpa or 0) / 68.95
 
 
 def _select_from_list(msg, items):

--- a/subarulink/app/cli.py
+++ b/subarulink/app/cli.py
@@ -75,7 +75,6 @@ class CLI:  # pylint: disable=too-few-public-methods
             saved_config = json.loads(config_json)
         else:
             write_config = True
-
         self._config = saved_config
 
         if "username" not in self._config:

--- a/subarulink/app/cli.py
+++ b/subarulink/app/cli.py
@@ -348,7 +348,6 @@ class CLI:  # pylint: disable=too-few-public-methods
                 self._cars = self._ctrl.get_vehicles()
                 await self._vehicle_select(interactive, vin)
                 if interactive:
-                    await self._fetch()
                     self._show(["summary"])
                 elif not interactive:
                     pass

--- a/subarulink/connection.py
+++ b/subarulink/connection.py
@@ -126,7 +126,8 @@ class Connection:
                     result = True
             else:
                 result = True
-        elif result is False:
+
+        if result is False:
             await self._authenticate(vin)
             # New session cookie.  Must call selectVehicle.json before any other API call.
             if await self._select_vehicle(vin):

--- a/subarulink/connection.py
+++ b/subarulink/connection.py
@@ -97,6 +97,8 @@ class Connection:
                 # Device registration does not always immediately take effect
                 await asyncio.sleep(3)
                 await self._authenticate()
+                # Current server side vin context is ambiguous (even for single vehicle account??)
+                self._current_vin = None
             return self._vehicles
 
     async def validate_session(self, vin):
@@ -229,7 +231,8 @@ class Connection:
         for vin in self._list_of_vins:
             # Strange issue where Subaru API won't report subscription data reliably unless you select vehicle
             # then refresh vehicles for each vehicle
-            await self._select_vehicle(vin)
+            # Also, sometimes VEHICLESETUPERROR happens on initial login???
+            await self.validate_session(vin)
             js_resp = await self.__open(API_REFRESH_VEHICLES, GET, params={"_": int(time.time())})
             _LOGGER.debug(pprint.pformat(js_resp))
             vin_data = [x for x in js_resp["data"]["vehicles"] if x["vin"] == vin]

--- a/subarulink/const.py
+++ b/subarulink/const.py
@@ -208,7 +208,7 @@ LOCATION_VALID = "location_valid"
 TIMESTAMP_FMT = "%Y-%m-%dT%H:%M:%S%z"  # "2020-04-25T23:35:55+0000"
 POSITION_TIMESTAMP_FMT = "%Y-%m-%dT%H:%M:%SZ"  # "2020-04-25T23:35:55Z"
 
-# Error Codes
+# G2 Error Codes
 ERROR_SOA_403 = "403-soa-unableToParseResponseBody"
 ERROR_INVALID_CREDENTIALS = "InvalidCredentials"
 ERROR_SERVICE_ALREADY_STARTED = "ServiceAlreadyStarted"
@@ -219,6 +219,13 @@ ERROR_NO_VEHICLES = "noVehiclesOnAccount"
 ERROR_NO_ACCOUNT = "accountNotFound"
 ERROR_TOO_MANY_ATTEMPTS = "tooManyAttempts"
 ERROR_VEHICLE_NOT_IN_ACCOUNT = "vehicleNotInAccount"
+
+# G1 Error Codes
+ERROR_G1_NO_SUBSCRIPTION = "SXM40004"
+ERROR_G1_STOLEN_VEHICLE = "SXM40005"
+ERROR_G1_INVALID_PIN = "SXM40006"
+ERROR_G1_SERVICE_ALREADY_STARTED = "SXM40009"
+ERROR_G1_PIN_LOCKED = "SXM40017"
 
 # Controller Vehicle Data Dict Keys
 VEHICLE_ATTRIBUTES = "attributes"

--- a/subarulink/const.py
+++ b/subarulink/const.py
@@ -27,6 +27,7 @@ API_VEHICLE_STATUS = "/vehicleStatus.json"
 API_AUTHORIZE_DEVICE = "/authenticateDevice.json"
 API_NAME_DEVICE = "/nameThisDevice.json"
 
+# TODO: Make command tuples (execute, status, cancel)
 # Similar API for g1 and g2 -- controller should replace 'api_gen' with either 'g1' or 'g2'
 API_LOCK = "/service/api_gen/lock/execute.json"
 API_LOCK_CANCEL = "/service/api_gen/lock/cancel.json"
@@ -51,6 +52,9 @@ API_G1_LOCATE_UPDATE = "/service/g1/vehicleLocate/execute.json"
 API_G1_LOCATE_STATUS = "/service/g1/vehicleLocate/status.json"
 API_G2_LOCATE_UPDATE = "/service/g2/vehicleStatus/execute.json"
 API_G2_LOCATE_STATUS = "/service/g2/vehicleStatus/locationStatus.json"
+
+# g1-Only API
+API_G1_HORN_LIGHTS_STATUS = "/service/g1/hornLights/status.json"
 
 # g2-Only API
 API_G2_SEND_POI = "/service/g2/sendPoi/execute.json"

--- a/subarulink/controller.py
+++ b/subarulink/controller.py
@@ -334,14 +334,13 @@ class Controller:
             SubaruException: If failure prevents a valid response from being received.
         """
         vin = vin.upper()
-        if self.get_safety_status(vin):
-            async with self._controller_lock:
-                last_fetch = self.get_last_fetch_time(vin)
-                cur_time = time.time()
-                if force or cur_time - last_fetch > self._fetch_interval:
-                    result = await self._fetch_status(vin)
-                    self._vehicles[vin][sc.VEHICLE_LAST_FETCH] = cur_time
-                    return result
+        async with self._controller_lock:
+            last_fetch = self.get_last_fetch_time(vin)
+            cur_time = time.time()
+            if force or cur_time - last_fetch > self._fetch_interval:
+                result = await self._fetch_status(vin)
+                self._vehicles[vin][sc.VEHICLE_LAST_FETCH] = cur_time
+                return result
 
     async def update(self, vin, force=False):
         """

--- a/subarulink/controller.py
+++ b/subarulink/controller.py
@@ -96,7 +96,7 @@ class Controller:
             if self.get_remote_status(vin):
                 await self._connection.validate_session(vin)
                 api_gen = self.get_api_gen(vin)
-                form_data = {"pin": self._pin}
+                form_data = {"pin": self._pin, "vin": vin, "delay": 0}
                 test_path = sc.API_G1_LOCATE_UPDATE if api_gen == sc.FEATURE_G1_TELEMATICS else sc.API_G2_LOCATE_UPDATE
                 async with self._vehicles[vin][sc.VEHICLE_LOCK]:
                     js_resp = await self._post(test_path, json_data=form_data)

--- a/subarulink/controller.py
+++ b/subarulink/controller.py
@@ -743,16 +743,15 @@ class Controller:
             )
 
             # Not sure if these fields are ever valid (or even appear) for non security plus subscribers.  They are always garbage on Crosstrek PHEV.
-            if not self.get_remote_status(vin):
+            status[sc.LOCATION_VALID] = False
+            if data.get(sc.VS_LONGITUDE) not in [sc.BAD_LONGITUDE, None] and data.get(sc.VS_LATITUDE) not in [
+                sc.BAD_LATITUDE,
+                None,
+            ]:
                 status[sc.LONGITUDE] = data.get(sc.VS_LONGITUDE)
                 status[sc.LATITUDE] = data.get(sc.VS_LATITUDE)
-                status[sc.HEADING] = data.get(sc.VS_HEADING)
+                status[sc.HEADING] = None
                 status[sc.LOCATION_VALID] = True
-                if status[sc.LONGITUDE] in [sc.BAD_LONGITUDE, None] and status[sc.LATITUDE] in [
-                    sc.BAD_LATITUDE,
-                    None,
-                ]:
-                    status[sc.LOCATION_VALID] = False
 
             self._vehicles[vin][sc.VEHICLE_STATUS].update(status)
 

--- a/subarulink/exceptions.py
+++ b/subarulink/exceptions.py
@@ -29,3 +29,7 @@ class InvalidCredentials(SubaruException):
 
 class PINLockoutProtect(SubaruException):
     """Class of exception to notify previous invalid PIN is not being used to avoid account lockout."""
+
+
+class VehicleNotSupported(SubaruException):
+    """Class of exception when service requested is not supported by vehicle/subscription."""

--- a/tests/api_responses.py
+++ b/tests/api_responses.py
@@ -558,7 +558,7 @@ LOGIN_MULTI_REGISTERED = {
         "termsAndConditionsAccepted": True,
         "tomtomKey": "0123456789ABCDEF01234567890ABCDE",
         "vehicleInactivated": False,
-        "vehicles": [_LOGIN_FAKE_CAR_1, _LOGIN_FAKE_CAR_2, _LOGIN_FAKE_CAR_3, _LOGIN_FAKE_CAR_4],
+        "vehicles": [_LOGIN_FAKE_CAR_1, _LOGIN_FAKE_CAR_2, _LOGIN_FAKE_CAR_3, _LOGIN_FAKE_CAR_4, _LOGIN_FAKE_CAR_5],
     },
     "dataName": "sessionData",
     "errorCode": None,
@@ -595,6 +595,10 @@ REFRESH_VEHICLES_SINGLE = {
 }
 
 # vehicle data fetched by refreshVehicles is incomplete for multicar accounts
+_REFRESH_VEHICLES_CAR_1 = deepcopy(FAKE_CAR_DATA_1)
+_REFRESH_VEHICLES_CAR_1.update({"features": None, "subscriptionFeatures": None})
+_REFRESH_VEHICLES_CAR_1.pop("vehicleGeoPosition")
+
 _REFRESH_VEHICLES_CAR_2 = deepcopy(FAKE_CAR_DATA_2)
 _REFRESH_VEHICLES_CAR_2.update({"features": None, "subscriptionFeatures": None})
 _REFRESH_VEHICLES_CAR_2.pop("vehicleGeoPosition")
@@ -632,7 +636,7 @@ REFRESH_VEHICLES_MULTI = {
         "tomtomKey": "0123456789ABCDEF01234567890ABCDE",
         "vehicleInactivated": False,
         "vehicles": [
-            FAKE_CAR_DATA_1,
+            _REFRESH_VEHICLES_CAR_1,
             _REFRESH_VEHICLES_CAR_2,
             _REFRESH_VEHICLES_CAR_3,
             _REFRESH_VEHICLES_CAR_4,
@@ -644,6 +648,71 @@ REFRESH_VEHICLES_MULTI = {
     "success": True,
 }
 
+# Attempting to mimic the Subaru API behavior where valid subscription data is only obtained in refreshVehicles after selectVehicle
+REFRESH_VEHICLES_MULTI_1 = deepcopy(REFRESH_VEHICLES_MULTI)
+REFRESH_VEHICLES_MULTI_1["data"].update(
+    {
+        "vehicles": [
+            FAKE_CAR_DATA_1,
+            _REFRESH_VEHICLES_CAR_2,
+            _REFRESH_VEHICLES_CAR_3,
+            _REFRESH_VEHICLES_CAR_4,
+            _REFRESH_VEHICLES_CAR_5,
+        ]
+    }
+)
+
+REFRESH_VEHICLES_MULTI_2 = deepcopy(REFRESH_VEHICLES_MULTI)
+REFRESH_VEHICLES_MULTI_2["data"].update(
+    {
+        "vehicles": [
+            _REFRESH_VEHICLES_CAR_1,
+            FAKE_CAR_DATA_2,
+            _REFRESH_VEHICLES_CAR_3,
+            _REFRESH_VEHICLES_CAR_4,
+            _REFRESH_VEHICLES_CAR_5,
+        ]
+    }
+)
+
+REFRESH_VEHICLES_MULTI_3 = deepcopy(REFRESH_VEHICLES_MULTI)
+REFRESH_VEHICLES_MULTI_3["data"].update(
+    {
+        "vehicles": [
+            _REFRESH_VEHICLES_CAR_1,
+            _REFRESH_VEHICLES_CAR_2,
+            FAKE_CAR_DATA_3,
+            _REFRESH_VEHICLES_CAR_4,
+            _REFRESH_VEHICLES_CAR_5,
+        ]
+    }
+)
+
+REFRESH_VEHICLES_MULTI_4 = deepcopy(REFRESH_VEHICLES_MULTI)
+REFRESH_VEHICLES_MULTI_4["data"].update(
+    {
+        "vehicles": [
+            _REFRESH_VEHICLES_CAR_1,
+            _REFRESH_VEHICLES_CAR_2,
+            _REFRESH_VEHICLES_CAR_3,
+            FAKE_CAR_DATA_4,
+            _REFRESH_VEHICLES_CAR_5,
+        ]
+    }
+)
+
+REFRESH_VEHICLES_MULTI_5 = deepcopy(REFRESH_VEHICLES_MULTI)
+REFRESH_VEHICLES_MULTI_5["data"].update(
+    {
+        "vehicles": [
+            _REFRESH_VEHICLES_CAR_1,
+            _REFRESH_VEHICLES_CAR_2,
+            _REFRESH_VEHICLES_CAR_3,
+            _REFRESH_VEHICLES_CAR_4,
+            FAKE_CAR_DATA_5,
+        ]
+    }
+)
 
 SELECT_VEHICLE_1 = {
     "data": FAKE_CAR_DATA_1,
@@ -1133,29 +1202,63 @@ VEHICLE_STATUS_FINISHED_SUCCESS = {
 }
 
 LOCATE_G1_EXECUTE = {
-    "serviceRequestId": "01234457-89ab-cdef-0123-456789abcdef",
-    "customerId": "1-TESTOEM_5",
-    "vin": "JF2ABCDE6L0000005",
-    "serviceType": "VEHICLE_LOCATOR",
+    "data": {
+        "cancelled": False,
+        "errorCode": None,
+        "remoteServiceState": None,
+        "remoteServiceType": "locate",
+        "result": None,
+        "serviceRequestId": "01234457-89ab-cdef-0123-456789abcdef",
+        "subState": None,
+        "success": False,
+        "updateTime": None,
+        "vin": "JF2ABCDE6L0000005",
+    },
+    "dataName": "remoteServiceStatus",
+    "errorCode": None,
+    "success": True,
 }
 
 LOCATE_G1_STARTED = {
-    "serviceRequestId": "01234457-89ab-cdef-0123-456789abcdef",
-    "status": "PENDING",
-    "customerId": "1-TESTOEM_5",
-    "vin": "JF2ABCDE6L0000005",
-    "serviceType": "VEHICLE_LOCATOR",
-    "statusChangeDateTime": "2020-11-09T17:05:00.000+0000",
+    "data": {
+        "cancelled": False,
+        "errorCode": None,
+        "remoteServiceState": "started",
+        "remoteServiceType": "locate",
+        "result": None,
+        "serviceRequestId": "01234457-89ab-cdef-0123-456789abcdef",
+        "subState": None,
+        "success": False,
+        "updateTime": 1607210415000,
+        "vin": "JF2ABCDE6L0000005",
+    },
+    "dataName": "remoteServiceStatus",
+    "errorCode": None,
+    "success": True,
 }
 
 LOCATE_G1_FINISHED = {
-    "serviceRequestId": "01234457-89ab-cdef-0123-456789abcdef",
-    "status": "SUCCESS",
-    "customerId": "1-TESTOEM_5",
-    "result": {"dateTime": "2020-11-09T17:10:00.000+0000", "latitude": "45.234", "longitude": "-77.0"},
-    "serviceType": "VEHICLE_LOCATOR",
-    "statusChangeDateTime": "2020-11-09T17:10:00.000+0000",
-    "vin": "JF2ABCDE6L0000005",
+    "data": {
+        "cancelled": False,
+        "errorCode": None,
+        "remoteServiceState": "finished",
+        "remoteServiceType": "locate",
+        "result": {
+            "heading": None,
+            "latitude": 45.234,
+            "locationTimestamp": 1607210423000,
+            "longitude": -77.0,
+            "speed": None,
+        },
+        "serviceRequestId": "01234457-89ab-cdef-0123-456789abcdef",
+        "subState": None,
+        "success": True,
+        "updateTime": 1607210425000,
+        "vin": "JF2ABCDE6L0000005",
+    },
+    "dataName": "remoteServiceStatus",
+    "errorCode": None,
+    "success": True,
 }
 
 GET_CLIMATE_SETTINGS_G2 = {

--- a/tests/common.py
+++ b/tests/common.py
@@ -11,7 +11,11 @@ from tests.aiohttp import CaseControlledTestServer, http_redirect
 from tests.api_responses import (
     LOGIN_MULTI_REGISTERED,
     LOGIN_SINGLE_REGISTERED,
-    REFRESH_VEHICLES_MULTI,
+    REFRESH_VEHICLES_MULTI_1,
+    REFRESH_VEHICLES_MULTI_2,
+    REFRESH_VEHICLES_MULTI_3,
+    REFRESH_VEHICLES_MULTI_4,
+    REFRESH_VEHICLES_MULTI_5,
     REFRESH_VEHICLES_SINGLE,
     SELECT_VEHICLE_1,
     SELECT_VEHICLE_2,
@@ -64,18 +68,28 @@ async def setup_multi_session(server, http_redirect):
     task = asyncio.create_task(controller.connect())
 
     await server_js_response(server, LOGIN_MULTI_REGISTERED, path=sc.API_LOGIN)
-    await server_js_response(
-        server, REFRESH_VEHICLES_MULTI, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
-    )
+
     await server_js_response(
         server, SELECT_VEHICLE_1, path=sc.API_SELECT_VEHICLE, query={"vin": TEST_VIN_1_G1, "_": str(int(time.time()))},
     )
     await server_js_response(
+        server, REFRESH_VEHICLES_MULTI_1, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
+    )
+
+    await server_js_response(
         server, SELECT_VEHICLE_2, path=sc.API_SELECT_VEHICLE, query={"vin": TEST_VIN_2_EV, "_": str(int(time.time()))},
     )
     await server_js_response(
+        server, REFRESH_VEHICLES_MULTI_2, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
+    )
+
+    await server_js_response(
         server, SELECT_VEHICLE_3, path=sc.API_SELECT_VEHICLE, query={"vin": TEST_VIN_3_G2, "_": str(int(time.time()))},
     )
+    await server_js_response(
+        server, REFRESH_VEHICLES_MULTI_3, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
+    )
+
     await server_js_response(
         server,
         SELECT_VEHICLE_4,
@@ -83,11 +97,19 @@ async def setup_multi_session(server, http_redirect):
         query={"vin": TEST_VIN_4_SAFETY_PLUS, "_": str(int(time.time()))},
     )
     await server_js_response(
+        server, REFRESH_VEHICLES_MULTI_4, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
+    )
+
+    await server_js_response(
         server,
         SELECT_VEHICLE_5,
         path=sc.API_SELECT_VEHICLE,
         query={"vin": TEST_VIN_5_G1_SECURITY, "_": str(int(time.time()))},
     )
+    await server_js_response(
+        server, REFRESH_VEHICLES_MULTI_5, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
+    )
+
     assert await task
     return controller
 
@@ -107,6 +129,9 @@ async def setup_single_session(server, http_redirect):
     task = asyncio.create_task(controller.connect())
 
     await server_js_response(server, LOGIN_SINGLE_REGISTERED, path=sc.API_LOGIN)
+    await server_js_response(
+        server, SELECT_VEHICLE_1, path=sc.API_SELECT_VEHICLE, query={"vin": TEST_VIN_1_G1, "_": str(int(time.time()))},
+    )
     await server_js_response(
         server, REFRESH_VEHICLES_SINGLE, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
     )

--- a/tests/common.py
+++ b/tests/common.py
@@ -22,6 +22,7 @@ from tests.api_responses import (
     SELECT_VEHICLE_3,
     SELECT_VEHICLE_4,
     SELECT_VEHICLE_5,
+    VALIDATE_SESSION_SUCCESS,
 )
 from tests.certificate import ssl_certificate
 
@@ -69,6 +70,7 @@ async def setup_multi_session(server, http_redirect):
 
     await server_js_response(server, LOGIN_MULTI_REGISTERED, path=sc.API_LOGIN)
 
+    await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
     await server_js_response(
         server, SELECT_VEHICLE_1, path=sc.API_SELECT_VEHICLE, query={"vin": TEST_VIN_1_G1, "_": str(int(time.time()))},
     )
@@ -76,6 +78,7 @@ async def setup_multi_session(server, http_redirect):
         server, REFRESH_VEHICLES_MULTI_1, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
     )
 
+    await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
     await server_js_response(
         server, SELECT_VEHICLE_2, path=sc.API_SELECT_VEHICLE, query={"vin": TEST_VIN_2_EV, "_": str(int(time.time()))},
     )
@@ -83,6 +86,7 @@ async def setup_multi_session(server, http_redirect):
         server, REFRESH_VEHICLES_MULTI_2, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
     )
 
+    await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
     await server_js_response(
         server, SELECT_VEHICLE_3, path=sc.API_SELECT_VEHICLE, query={"vin": TEST_VIN_3_G2, "_": str(int(time.time()))},
     )
@@ -90,6 +94,7 @@ async def setup_multi_session(server, http_redirect):
         server, REFRESH_VEHICLES_MULTI_3, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
     )
 
+    await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
     await server_js_response(
         server,
         SELECT_VEHICLE_4,
@@ -100,6 +105,7 @@ async def setup_multi_session(server, http_redirect):
         server, REFRESH_VEHICLES_MULTI_4, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
     )
 
+    await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
     await server_js_response(
         server,
         SELECT_VEHICLE_5,
@@ -129,6 +135,7 @@ async def setup_single_session(server, http_redirect):
     task = asyncio.create_task(controller.connect())
 
     await server_js_response(server, LOGIN_SINGLE_REGISTERED, path=sc.API_LOGIN)
+    await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
     await server_js_response(
         server, SELECT_VEHICLE_1, path=sc.API_SELECT_VEHICLE, query={"vin": TEST_VIN_1_G1, "_": str(int(time.time()))},
     )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -21,7 +21,11 @@ from tests.api_responses import (
     LOGIN_MULTI_REGISTERED,
     LOGIN_SINGLE_NOT_REGISTERED,
     LOGIN_SINGLE_REGISTERED,
-    REFRESH_VEHICLES_MULTI,
+    REFRESH_VEHICLES_MULTI_1,
+    REFRESH_VEHICLES_MULTI_2,
+    REFRESH_VEHICLES_MULTI_3,
+    REFRESH_VEHICLES_MULTI_4,
+    REFRESH_VEHICLES_MULTI_5,
     REFRESH_VEHICLES_SINGLE,
     REMOTE_CMD_INVALID_PIN,
     REMOTE_SERVICE_EXECUTE,
@@ -123,6 +127,12 @@ async def test_connect_device_registration(http_redirect, ssl_certificate):
 
             await server_js_response(server, LOGIN_SINGLE_NOT_REGISTERED, path=sc.API_LOGIN)
             await server_js_response(
+                server,
+                SELECT_VEHICLE_1,
+                path=sc.API_SELECT_VEHICLE,
+                query={"vin": TEST_VIN_1_G1, "_": str(int(time.time()))},
+            )
+            await server_js_response(
                 server, REFRESH_VEHICLES_SINGLE, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
             )
             await server_js_response(server, True, path=sc.WEB_API_LOGIN)
@@ -147,6 +157,12 @@ async def test_connect_single_car(http_redirect, ssl_certificate):
 
         await server_js_response(server, LOGIN_SINGLE_REGISTERED, path=sc.API_LOGIN)
         await server_js_response(
+            server,
+            SELECT_VEHICLE_1,
+            path=sc.API_SELECT_VEHICLE,
+            query={"vin": TEST_VIN_1_G1, "_": str(int(time.time()))},
+        )
+        await server_js_response(
             server, REFRESH_VEHICLES_SINGLE, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
         )
 
@@ -166,9 +182,7 @@ async def test_connect_multi_car(http_redirect, ssl_certificate):
         task = asyncio.create_task(controller.connect())
 
         await server_js_response(server, LOGIN_MULTI_REGISTERED, path=sc.API_LOGIN)
-        await server_js_response(
-            server, REFRESH_VEHICLES_MULTI, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
-        )
+
         await server_js_response(
             server,
             SELECT_VEHICLE_1,
@@ -176,11 +190,19 @@ async def test_connect_multi_car(http_redirect, ssl_certificate):
             query={"vin": TEST_VIN_1_G1, "_": str(int(time.time()))},
         )
         await server_js_response(
+            server, REFRESH_VEHICLES_MULTI_1, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
+        )
+
+        await server_js_response(
             server,
             SELECT_VEHICLE_2,
             path=sc.API_SELECT_VEHICLE,
             query={"vin": TEST_VIN_2_EV, "_": str(int(time.time()))},
         )
+        await server_js_response(
+            server, REFRESH_VEHICLES_MULTI_2, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
+        )
+
         await server_js_response(
             server,
             SELECT_VEHICLE_3,
@@ -188,16 +210,27 @@ async def test_connect_multi_car(http_redirect, ssl_certificate):
             query={"vin": TEST_VIN_3_G2, "_": str(int(time.time()))},
         )
         await server_js_response(
+            server, REFRESH_VEHICLES_MULTI_3, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
+        )
+
+        await server_js_response(
             server,
             SELECT_VEHICLE_4,
             path=sc.API_SELECT_VEHICLE,
             query={"vin": TEST_VIN_4_SAFETY_PLUS, "_": str(int(time.time()))},
         )
         await server_js_response(
+            server, REFRESH_VEHICLES_MULTI_4, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
+        )
+
+        await server_js_response(
             server,
             SELECT_VEHICLE_5,
             path=sc.API_SELECT_VEHICLE,
             query={"vin": TEST_VIN_5_G1_SECURITY, "_": str(int(time.time()))},
+        )
+        await server_js_response(
+            server, REFRESH_VEHICLES_MULTI_5, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
         )
 
         response = await task
@@ -207,6 +240,7 @@ async def test_connect_multi_car(http_redirect, ssl_certificate):
         assert TEST_VIN_2_EV in vehicles
         assert TEST_VIN_3_G2 in vehicles
         assert TEST_VIN_4_SAFETY_PLUS in vehicles
+        assert TEST_VIN_5_G1_SECURITY in vehicles
         assert not controller.get_ev_status(TEST_VIN_1_G1)
         assert controller.get_ev_status(TEST_VIN_2_EV)
         assert not controller.get_remote_status(TEST_VIN_1_G1)
@@ -227,6 +261,12 @@ async def test_test_login_success(http_redirect, ssl_certificate):
         task = asyncio.create_task(controller.connect(test_login=True))
 
         await server_js_response(server, LOGIN_SINGLE_REGISTERED, path=sc.API_LOGIN)
+        await server_js_response(
+            server,
+            SELECT_VEHICLE_1,
+            path=sc.API_SELECT_VEHICLE,
+            query={"vin": TEST_VIN_1_G1, "_": str(int(time.time()))},
+        )
         await server_js_response(
             server, REFRESH_VEHICLES_SINGLE, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
         )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -126,6 +126,7 @@ async def test_connect_device_registration(http_redirect, ssl_certificate):
             task = asyncio.create_task(controller.connect())
 
             await server_js_response(server, LOGIN_SINGLE_NOT_REGISTERED, path=sc.API_LOGIN)
+            await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
             await server_js_response(
                 server,
                 SELECT_VEHICLE_1,
@@ -156,6 +157,7 @@ async def test_connect_single_car(http_redirect, ssl_certificate):
         task = asyncio.create_task(controller.connect())
 
         await server_js_response(server, LOGIN_SINGLE_REGISTERED, path=sc.API_LOGIN)
+        await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
         await server_js_response(
             server,
             SELECT_VEHICLE_1,
@@ -182,6 +184,7 @@ async def test_connect_multi_car(http_redirect, ssl_certificate):
         task = asyncio.create_task(controller.connect())
 
         await server_js_response(server, LOGIN_MULTI_REGISTERED, path=sc.API_LOGIN)
+        await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
 
         await server_js_response(
             server,
@@ -193,6 +196,7 @@ async def test_connect_multi_car(http_redirect, ssl_certificate):
             server, REFRESH_VEHICLES_MULTI_1, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
         )
 
+        await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
         await server_js_response(
             server,
             SELECT_VEHICLE_2,
@@ -203,6 +207,7 @@ async def test_connect_multi_car(http_redirect, ssl_certificate):
             server, REFRESH_VEHICLES_MULTI_2, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
         )
 
+        await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
         await server_js_response(
             server,
             SELECT_VEHICLE_3,
@@ -213,6 +218,7 @@ async def test_connect_multi_car(http_redirect, ssl_certificate):
             server, REFRESH_VEHICLES_MULTI_3, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
         )
 
+        await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
         await server_js_response(
             server,
             SELECT_VEHICLE_4,
@@ -223,6 +229,7 @@ async def test_connect_multi_car(http_redirect, ssl_certificate):
             server, REFRESH_VEHICLES_MULTI_4, path=sc.API_REFRESH_VEHICLES, query={"_": str(int(time.time()))},
         )
 
+        await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
         await server_js_response(
             server,
             SELECT_VEHICLE_5,
@@ -261,6 +268,7 @@ async def test_test_login_success(http_redirect, ssl_certificate):
         task = asyncio.create_task(controller.connect(test_login=True))
 
         await server_js_response(server, LOGIN_SINGLE_REGISTERED, path=sc.API_LOGIN)
+        await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
         await server_js_response(
             server,
             SELECT_VEHICLE_1,

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -184,7 +184,7 @@ async def test_remote_cmd_timeout_g1(http_redirect, ssl_certificate):
                 server, LOCATE_G1_EXECUTE, path=sc.API_LIGHTS,
             )
             for _ in range(0, 20):
-                await server_js_response(server, LOCATE_G1_STARTED, path=sc.API_REMOTE_SVC_STATUS)
+                await server_js_response(server, LOCATE_G1_STARTED, path=sc.API_G1_HORN_LIGHTS_STATUS)
 
             assert not await task
 

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -23,7 +23,6 @@ from tests.api_responses import (
     SAVE_CLIMATE_SETTINGS,
     SELECT_VEHICLE_2,
     SELECT_VEHICLE_3,
-    SELECT_VEHICLE_5,
     VALIDATE_SESSION_FAIL,
     VALIDATE_SESSION_SUCCESS,
 )
@@ -181,12 +180,6 @@ async def test_remote_cmd_timeout_g1(http_redirect, ssl_certificate):
             task = asyncio.create_task(controller.lights(TEST_VIN_5_G1_SECURITY))
 
             await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
-            await server_js_response(
-                server,
-                SELECT_VEHICLE_5,
-                path=sc.API_SELECT_VEHICLE,
-                query={"vin": TEST_VIN_5_G1_SECURITY, "_": str(int(time.time()))},
-            )
             await server_js_response(
                 server, LOCATE_G1_EXECUTE, path=sc.API_LIGHTS,
             )

--- a/tests/test_vehicle_status.py
+++ b/tests/test_vehicle_status.py
@@ -22,6 +22,7 @@ from tests.api_responses import (
     LOCATE_G1_STARTED,
     LOCATE_G2,
     LOCATE_G2_BAD_LOCATION,
+    SELECT_VEHICLE_1,
     SELECT_VEHICLE_2,
     SELECT_VEHICLE_3,
     SELECT_VEHICLE_4,
@@ -222,7 +223,15 @@ async def test_get_vehicle_status_no_subscription(http_redirect, ssl_certificate
         controller = await setup_multi_session(server, http_redirect)
 
         task = asyncio.create_task(controller.get_data(TEST_VIN_1_G1))
-        assert await task
+        await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
+        await server_js_response(
+            server,
+            SELECT_VEHICLE_1,
+            path=sc.API_SELECT_VEHICLE,
+            query={"vin": TEST_VIN_1_G1, "_": str(int(time.time()))},
+        )
+        await server_js_response(server, VEHICLE_STATUS_G2_NO_TIRE_PRESSURE, path=sc.API_VEHICLE_STATUS)
+        await task
 
 
 @pytest.mark.asyncio

--- a/tests/test_vehicle_status.py
+++ b/tests/test_vehicle_status.py
@@ -26,7 +26,6 @@ from tests.api_responses import (
     SELECT_VEHICLE_2,
     SELECT_VEHICLE_3,
     SELECT_VEHICLE_4,
-    SELECT_VEHICLE_5,
     VALIDATE_SESSION_SUCCESS,
     VEHICLE_STATUS_EV,
     VEHICLE_STATUS_EXECUTE,
@@ -267,12 +266,6 @@ async def test_update_g1(http_redirect, ssl_certificate):
 
             task = asyncio.create_task(controller.update(TEST_VIN_5_G1_SECURITY))
             await server_js_response(server, VALIDATE_SESSION_SUCCESS, path=sc.API_VALIDATE_SESSION)
-            await server_js_response(
-                server,
-                SELECT_VEHICLE_5,
-                path=sc.API_SELECT_VEHICLE,
-                query={"vin": TEST_VIN_5_G1_SECURITY, "_": str(int(time.time()))},
-            )
             await server_js_response(
                 server, LOCATE_G1_EXECUTE, path=sc.API_G1_LOCATE_UPDATE,
             )


### PR DESCRIPTION
Will be missing features found in g2 (2019+) vehicles, but should have all remote functionality that is provided by the official Subaru mobile app.
- Lock/Unlock
- Light/Horn
- Locate
- Odometer value is available but the vehicle only pushes updates every 500 miles.  There doesn't appear to be a way to force an update