### PR TITLE
Bubble up rejection reason from data.errorCode

### DIFF
--- a/subarulink/controller.py
+++ b/subarulink/controller.py
@@ -1233,12 +1233,18 @@ class Controller:
                     if data.get("success"):
                         _LOGGER.info("Remote service request completed successfully: %s", req_id)
                         return True, js_resp
+                    # When Subaru rejects the operation after acknowledging it (e.g. low fuel,
+                    # consecutive remote-start limit, vehicle precondition), the reason lives
+                    # in data.errorCode -- the top-level errorCode is null on this path.
+                    reason = data.get("errorCode") or js_resp.get("errorCode") or "unknown"
+                    if description := data.get("errorDescription"):
+                        reason = f"{reason}: {description}"
                     _LOGGER.error(
                         "Remote service request completed but failed: %s Error: %s",
                         req_id,
-                        js_resp["errorCode"],
+                        reason,
                     )
-                    raise RemoteServiceFailure("Remote service request completed but failed: %s" % js_resp["errorCode"])
+                    raise RemoteServiceFailure("Remote service request completed but failed: %s" % reason)
                 if data.get("remoteServiceState") == "started":
                     _LOGGER.info(
                         "Subaru API reports remote service request is in progress: %s",
@@ -1247,9 +1253,9 @@ class Controller:
                     attempts_left -= 1
                     await asyncio.sleep(2)
                     continue
-        _LOGGER.error("Remote service request completion message never received: %s", js_resp["errorCode"])
+        _LOGGER.error("Remote service request completion message never received: %s", req_id)
         raise RemoteServiceFailure(
-            "Remote service request completion message never received: %s" % js_resp["errorCode"]
+            "Remote service request completion message never received: %s" % req_id
         )
 
     async def _fetch_climate_presets(self, vin: str) -> bool:

--- a/subarulink/controller.py
+++ b/subarulink/controller.py
@@ -1254,9 +1254,7 @@ class Controller:
                     await asyncio.sleep(2)
                     continue
         _LOGGER.error("Remote service request completion message never received: %s", req_id)
-        raise RemoteServiceFailure(
-            "Remote service request completion message never received: %s" % req_id
-        )
+        raise RemoteServiceFailure("Remote service request completion message never received: %s" % req_id)
 
     async def _fetch_climate_presets(self, vin: str) -> bool:
         vin = vin.upper()

--- a/tests/api_responses.py
+++ b/tests/api_responses.py
@@ -259,6 +259,26 @@ REMOTE_SERVICE_STATUS_FINISHED_FAIL = {
     "success": True,
 }
 
+# Subaru returns the rejection reason in data.errorCode (top-level errorCode is null on this path).
+# Real-world examples: "NegativeAcknowledge:otherCommandsOngoing", "NegativeAcknowledge:lowFuel".
+REMOTE_SERVICE_STATUS_FINISHED_FAIL_LOW_FUEL = {
+    "data": {
+        "cancelled": False,
+        "errorCode": "NegativeAcknowledge:lowFuel",
+        "remoteServiceState": "finished",
+        "remoteServiceType": "engineStart",
+        "result": None,
+        "serviceRequestId": "JF2ABCDE6L0000002_1595799253112_22_@NGTP",
+        "subState": None,
+        "success": False,
+        "updateTime": 1595799258000,
+        "vin": "JF2ABCDE6L0000002",
+    },
+    "dataName": "remoteServiceStatus",
+    "errorCode": None,
+    "success": True,
+}
+
 REMOTE_SERVICE_STATUS_INVALID_TOKEN = {
     "success": False,
     "errorCode": "InvalidToken",

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -42,6 +42,7 @@ from tests.api_responses import (
     REMOTE_CMD_INVALID_PIN,
     REMOTE_SERVICE_EXECUTE,
     REMOTE_SERVICE_STATUS_FINISHED_FAIL,
+    REMOTE_SERVICE_STATUS_FINISHED_FAIL_LOW_FUEL,
     REMOTE_SERVICE_STATUS_FINISHED_SUCCESS,
     REMOTE_SERVICE_STATUS_INVALID_TOKEN,
     REMOTE_SERVICE_STATUS_STARTED,
@@ -274,6 +275,33 @@ async def test_remote_cmd_failure(test_server, multi_vehicle_controller):
     )
     with pytest.raises(RemoteServiceFailure):
         assert not await task
+
+
+async def test_remote_cmd_failure_bubbles_data_error_code(test_server, multi_vehicle_controller):
+    """When Subaru rejects the command (e.g. low fuel), the reason from data.errorCode should
+    appear in the RemoteServiceFailure message instead of being reduced to None."""
+    task = asyncio.create_task(multi_vehicle_controller.lights(TEST_VIN_3_G2))
+
+    await server_js_response(test_server, VALIDATE_SESSION_SUCCESS, path=API_VALIDATE_SESSION)
+    await server_js_response(
+        test_server,
+        SELECT_VEHICLE_3,
+        path=API_SELECT_VEHICLE,
+        query={"vin": TEST_VIN_3_G2, "_": str(int(time.time()))},
+    )
+    await server_js_response(
+        test_server,
+        REMOTE_SERVICE_EXECUTE,
+        path=API_LIGHTS,
+    )
+    await server_js_response(
+        test_server,
+        REMOTE_SERVICE_STATUS_FINISHED_FAIL_LOW_FUEL,
+        path=API_REMOTE_SVC_STATUS,
+    )
+    with pytest.raises(RemoteServiceFailure) as exc_info:
+        await task
+    assert "lowFuel" in exc_info.value.message
 
 
 async def test_remote_cmd_timeout_g2(test_server, multi_vehicle_controller):


### PR DESCRIPTION
## Problem

When the MySubaru API acknowledges a remote command but then rejects the operation (low fuel, consecutive remote-start limit, vehicle in motion, weak battery, etc.), the rejection reason is reported in `js_resp[\"data\"][\"errorCode\"]` while the top-level `js_resp[\"errorCode\"]` is `null`.

The current code in `_wait_request_status` looks at the wrong field on the finished-but-failed path:

```python
raise RemoteServiceFailure(\"Remote service request completed but failed: %s\" % js_resp[\"errorCode\"])
```

…so callers see:

```
Remote service request completed but failed: None
```

…regardless of why Subaru rejected the operation. This is what surfaces today when the integration is asked to remote-start a vehicle with insufficient fuel — the integration faithfully forwards the empty reason and users have no way to know they need to gas up. The same pattern hits `NegativeAcknowledge:otherCommandsOngoing` (issue [#112](https://github.com/G-Two/homeassistant-subaru/issues/112) on the HA integration), `lowFuel`, etc.

The behavior was a regression from commit 0c6b8cf (\"Improve error handling for remote commands\"), which moved the read from `js_resp[\"data\"][\"errorCode\"]` to `js_resp[\"errorCode\"]`.

## Fix

Read `data.errorCode` first, fall back to top-level `errorCode`, and append `data.errorDescription` when the API provides one. Also stop the never-received-completion branch from raising a `KeyError` when there is no `errorCode` to format (the only path that branch reaches).

Resulting message looks like:

```
Remote service request completed but failed: NegativeAcknowledge:lowFuel
```

## Tests

Added `test_remote_cmd_failure_bubbles_data_error_code` plus a `REMOTE_SERVICE_STATUS_FINISHED_FAIL_LOW_FUEL` fixture that asserts the reason flows through the exception. All 42 existing tests still pass.

```
============================== 42 passed in 2.66s ==============================
```